### PR TITLE
HSDO-29 Added site owner to view reports pages

### DIFF
--- a/modules/stanford_jumpstart_lab_permissions/stanford_jumpstart_lab_permissions.features.user_permission.inc
+++ b/modules/stanford_jumpstart_lab_permissions/stanford_jumpstart_lab_permissions.features.user_permission.inc
@@ -114,6 +114,7 @@ function stanford_jumpstart_lab_permissions_user_default_permissions() {
     'name' => 'access site reports',
     'roles' => array(
       'administrator' => 'administrator',
+      'site owner' => 'site owner',
     ),
     'module' => 'system',
   );


### PR DESCRIPTION
# Not READY FOR REVIEW

# Summary
- Added site owner to view reports pages

# Needed By (Date)
- End of sprint

# Urgency
- low

# Steps to Test

1. Checkout branch
2. revert feature `drush fr stanford_jumpstart_lab_permissions -y`
3. validate site owner can view the 404 reports page.


# Related
https://github.com/SU-SWS/stanford_jumpstart/pull/78