### PR TITLE
HSDO-1063 HSDO-1061 Removed advanced search and admin menu permissions

### DIFF
--- a/modules/stanford_jumpstart_lab_permissions/stanford_jumpstart_lab_permissions.features.user_permission.inc
+++ b/modules/stanford_jumpstart_lab_permissions/stanford_jumpstart_lab_permissions.features.user_permission.inc
@@ -15,7 +15,6 @@ function stanford_jumpstart_lab_permissions_user_default_permissions() {
     'name' => 'access administration menu',
     'roles' => array(
       'administrator' => 'administrator',
-      'site owner' => 'site owner',
     ),
     'module' => 'admin_menu',
   );
@@ -2562,8 +2561,6 @@ function stanford_jumpstart_lab_permissions_user_default_permissions() {
     'name' => 'use advanced search',
     'roles' => array(
       'administrator' => 'administrator',
-      'anonymous user' => 'anonymous user',
-      'authenticated user' => 'authenticated user',
     ),
     'module' => 'search',
   );


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removed advanced search for anonymous users
- Removed admin menu for site owners

# Needed By (Date)
- End of sprint

# Urgency
- low

# Steps to Test

1. Checkout branch
2. either do site install or `drush fr stanford_jumpstart_lab_permissions -y`
3. verify anonymous doesn't see advanced search & site owner doesn't see admin menu.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)